### PR TITLE
Revert "pip-prod(deps): bump click from 7.1.2 to 8.0.1"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,7 @@ blinker==1.4
 celery==5.1.2
 certifi==2021.5.30
 cffi==1.14.6
-click==8.0.1
+click==7.1.2
 click-didyoumean==0.0.3
 click-plugins==1.1.1
 click-repl==0.2.0


### PR DESCRIPTION
Reverts ZenithClown/flask-docker-template#3 as build fail due to `celery` dependency error. Check [build log](https://app.travis-ci.com/github/ZenithClown/flask-docker-template/jobs/535797120) for more information.